### PR TITLE
Add docker images combining bedtools and bgzip and update code to compress filtered vcf files (issue #19)

### DIFF
--- a/workflow/docker/bedtools-2.29.2/Dockerfile
+++ b/workflow/docker/bedtools-2.29.2/Dockerfile
@@ -17,14 +17,14 @@ RUN apt update -y && apt install -y \
 WORKDIR /bedtools
 
 RUN wget https://github.com/arq5x/bedtools2/releases/download/v2.29.2/bedtools.static.binary && \
-        mv bedtools.static.binary /bedtools/bedtools && \
-        chmod a+x /bedtools/bedtools
+		mv bedtools.static.binary /bedtools/bedtools && \
+		chmod a+x /bedtools/bedtools
 
 FROM ubuntu:18.04 AS production
 RUN apt update -y && apt install -y \
 	libcurl4-gnutls-dev
-# COPY --from=nbisweden/generode-htslib-1.15.1:latest /htslib/bgzip /usr/bin
-# COPY --from=nbisweden/generode-htslib-1.15.1:latest /htslib/tabix /usr/bin
-COPY --from=verku/htslib-1.15.1:latest /htslib/bgzip /usr/bin
-COPY --from=verku/htslib-1.15.1:latest /htslib/tabix /usr/bin
+COPY --from=nbisweden/generode-htslib-1.15.1:latest /htslib/bgzip /usr/bin
+COPY --from=nbisweden/generode-htslib-1.15.1:latest /htslib/tabix /usr/bin
+# COPY --from=verku/htslib-1.15.1:latest /htslib/bgzip /usr/bin # container used for development
+# COPY --from=verku/htslib-1.15.1:latest /htslib/tabix /usr/bin # container used for development
 COPY --from=builder /bedtools/bedtools /usr/bin/

--- a/workflow/docker/bedtools-2.29.2/Dockerfile
+++ b/workflow/docker/bedtools-2.29.2/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:18.04 AS builder
+MAINTAINER NBIS Sweden <generode@nbis.se>
+RUN apt update -y && apt install -y \
+	autoconf \
+	automake \
+	gcc \
+	libbz2-dev \
+	libcurl4-gnutls-dev \
+	liblzma-dev \
+	libncurses5-dev \
+	libssl-dev \
+	make \
+	perl \
+	wget \
+	zlib1g-dev
+
+WORKDIR /bedtools
+
+RUN wget https://github.com/arq5x/bedtools2/releases/download/v2.29.2/bedtools.static.binary && \
+        mv bedtools.static.binary /bedtools/bedtools && \
+        chmod a+x /bedtools/bedtools
+
+FROM ubuntu:18.04 AS production
+RUN apt update -y && apt install -y \
+	libcurl4-gnutls-dev
+# COPY --from=nbisweden/generode-htslib-1.15.1:latest /htslib/bgzip /usr/bin
+# COPY --from=nbisweden/generode-htslib-1.15.1:latest /htslib/tabix /usr/bin
+COPY --from=verku/htslib-1.15.1:latest /htslib/bgzip /usr/bin
+COPY --from=verku/htslib-1.15.1:latest /htslib/tabix /usr/bin
+COPY --from=builder /bedtools/bedtools /usr/bin/

--- a/workflow/docker/htslib-1.15.1/Dockerfile
+++ b/workflow/docker/htslib-1.15.1/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:18.04 AS builder
+MAINTAINER NBIS Sweden <generode@nbis.se>
+RUN apt update -y && apt install -y \
+	autoconf \
+	automake \
+	gcc \
+	libbz2-dev \
+	libcurl4-gnutls-dev \
+	liblzma-dev \
+	libncurses5-dev \
+	libssl-dev \
+	make \ 
+	perl \
+	wget \ 
+	zlib1g-dev
+
+WORKDIR /htslib
+RUN 	wget https://github.com/samtools/htslib/releases/download/1.15.1/htslib-1.15.1.tar.bz2 && \
+	bunzip2 htslib-1.15.1.tar.bz2 && \
+	tar xfv htslib-1.15.1.tar && \
+	cd htslib-1.15.1 && \
+	./configure && \
+	make && \
+	cp bgzip /htslib/ && \
+	cp tabix /htslib/ && \
+	make install

--- a/workflow/rules/0.2_repeat_identification.smk
+++ b/workflow/rules/0.2_repeat_identification.smk
@@ -214,7 +214,7 @@ rule sort_repeats_bed:
     log:
         "results/logs/0.2_repeat_identification/" + REF_NAME + "_sort_repeats_bed.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         bedtools sort -g {input.genomefile} -i {input.rep_bed} > {output.sorted_rep_bed} 2> {log}
@@ -233,7 +233,7 @@ rule make_no_repeats_bed:
     log:
         "results/logs/0.2_repeat_identification/" + REF_NAME + "_make_no_repeats_bed.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         bedtools subtract -a {input.ref_bed} -b {input.sorted_rep_bed} > {output.no_rep_bed} 2> {log} &&

--- a/workflow/rules/0.2_repeat_identification.smk
+++ b/workflow/rules/0.2_repeat_identification.smk
@@ -214,7 +214,7 @@ rule sort_repeats_bed:
     log:
         "results/logs/0.2_repeat_identification/" + REF_NAME + "_sort_repeats_bed.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         bedtools sort -g {input.genomefile} -i {input.rep_bed} > {output.sorted_rep_bed} 2> {log}
@@ -233,7 +233,7 @@ rule make_no_repeats_bed:
     log:
         "results/logs/0.2_repeat_identification/" + REF_NAME + "_make_no_repeats_bed.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         bedtools subtract -a {input.ref_bed} -b {input.sorted_rep_bed} > {output.no_rep_bed} 2> {log} &&

--- a/workflow/rules/12_snpEff.smk
+++ b/workflow/rules/12_snpEff.smk
@@ -249,7 +249,7 @@ rule filter_biallelic_missing_vcf_snpEff:
     log:
         "results/logs/12_snpEff/{dataset}/" + REF_NAME + "/{sample}.{processed}_fmissing{fmiss}_filter_biallelic_missing_vcf.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         bedtools intersect -a {input.vcf} -b {input.bed} -header -sorted -g {input.genomefile} > {output.filtered} 2> {log}

--- a/workflow/rules/12_snpEff.smk
+++ b/workflow/rules/12_snpEff.smk
@@ -244,7 +244,7 @@ rule filter_biallelic_missing_vcf_snpEff:
         bed=rules.filtered_vcf2bed.output.bed,
         genomefile=rules.genome_file.output.genomefile,
     output:
-        filtered=temp("results/{dataset}/snpEff/" + REF_NAME + "/{sample}.merged.rmdup.merged.{processed}.snps5.noIndel.QUAL30.dp.AB.repma.biallelic.fmissing{fmiss}.vcf"),
+        filtered=temp("results/{dataset}/snpEff/" + REF_NAME + "/{sample}.merged.rmdup.merged.{processed}.snps5.noIndel.QUAL30.dp.AB.repma.biallelic.fmissing{fmiss}.vcf.gz"),
     threads: 6
     log:
         "results/logs/12_snpEff/{dataset}/" + REF_NAME + "/{sample}.{processed}_fmissing{fmiss}_filter_biallelic_missing_vcf.log",
@@ -252,7 +252,7 @@ rule filter_biallelic_missing_vcf_snpEff:
         "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
-        bedtools intersect -a {input.vcf} -b {input.bed} -header -sorted -g {input.genomefile} > {output.filtered} 2> {log}
+        bedtools intersect -a {input.vcf} -b {input.bed} -header -sorted -g {input.genomefile} | bgzip -c > {output.filtered} 2> {log}
         """
 
 

--- a/workflow/rules/12_snpEff.smk
+++ b/workflow/rules/12_snpEff.smk
@@ -249,7 +249,7 @@ rule filter_biallelic_missing_vcf_snpEff:
     log:
         "results/logs/12_snpEff/{dataset}/" + REF_NAME + "/{sample}.{processed}_fmissing{fmiss}_filter_biallelic_missing_vcf.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         bedtools intersect -a {input.vcf} -b {input.bed} -header -sorted -g {input.genomefile} | bgzip -c > {output.filtered} 2> {log}

--- a/workflow/rules/13_GERP.smk
+++ b/workflow/rules/13_GERP.smk
@@ -810,7 +810,7 @@ rule filter_biallelic_missing_vcf_gerp:
         bed=rules.filtered_vcf2bed.output.bed,
         genomefile=rules.genome_file.output.genomefile,
     output:
-        filtered=temp("results/gerp/{dataset}/" + REF_NAME + "/vcf/{sample}.merged.rmdup.merged.{processed}.snps5.noIndel.QUAL30.dp.AB.repma.biallelic.fmissing{fmiss}.vcf"),
+        filtered=temp("results/gerp/{dataset}/" + REF_NAME + "/vcf/{sample}.merged.rmdup.merged.{processed}.snps5.noIndel.QUAL30.dp.AB.repma.biallelic.fmissing{fmiss}.vcf.gz"),
     threads: 6
     log:
         "results/logs/13_GERP/{dataset}/" + REF_NAME + "/vcf/{sample}.{processed}_fmissing{fmiss}_filter_biallelic_missing_vcf.log",
@@ -818,14 +818,14 @@ rule filter_biallelic_missing_vcf_gerp:
         "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
-        bedtools intersect -a {input.vcf} -b {input.bed} -header -sorted -g {input.genomefile} > {output.filtered} 2> {log}
+        bedtools intersect -a {input.vcf} -b {input.bed} -header -sorted -g {input.genomefile} | bgzip -c > {output.filtered} 2> {log}
         """
 
 
 rule biallelic_missing_filtered_vcf_gerp_stats:
     """Obtain summary stats of filtered vcf file"""
     input:
-        filtered="results/gerp/{dataset}/" + REF_NAME + "/vcf/{sample}.merged.rmdup.merged.{processed}.snps5.noIndel.QUAL30.dp.AB.repma.biallelic.fmissing{fmiss}.vcf",
+        filtered="results/gerp/{dataset}/" + REF_NAME + "/vcf/{sample}.merged.rmdup.merged.{processed}.snps5.noIndel.QUAL30.dp.AB.repma.biallelic.fmissing{fmiss}.vcf.gz",
     output:
         stats="results/gerp/{dataset}/" + REF_NAME + "/vcf/stats/{sample}.merged.rmdup.merged.{processed}.snps5.noIndel.QUAL30.dp.AB.repma.biallelic.fmissing{fmiss}.vcf.stats.txt",
     log:
@@ -879,7 +879,7 @@ rule modern_biallelic_missing_filtered_vcf_gerp_multiqc:
 rule split_vcf_files:
     """Split the VCF files into chunks for more resource-efficient merging with GERP results"""
     input:
-        vcf="results/gerp/{dataset}/" + REF_NAME + "/vcf/{sample}.merged.rmdup.merged.{processed}.snps5.noIndel.QUAL30.dp.AB.repma.biallelic.fmissing{fmiss}.vcf",
+        vcf="results/gerp/{dataset}/" + REF_NAME + "/vcf/{sample}.merged.rmdup.merged.{processed}.snps5.noIndel.QUAL30.dp.AB.repma.biallelic.fmissing{fmiss}.vcf.gz",
         chunk_bed=REF_DIR + "/gerp/" + REF_NAME + "/split_bed_files/{chunk}.bed",
         genomefile=REF_DIR + "/" + REF_NAME + ".genome",
     output:

--- a/workflow/rules/13_GERP.smk
+++ b/workflow/rules/13_GERP.smk
@@ -815,7 +815,7 @@ rule filter_biallelic_missing_vcf_gerp:
     log:
         "results/logs/13_GERP/{dataset}/" + REF_NAME + "/vcf/{sample}.{processed}_fmissing{fmiss}_filter_biallelic_missing_vcf.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         bedtools intersect -a {input.vcf} -b {input.bed} -header -sorted -g {input.genomefile} | bgzip -c > {output.filtered} 2> {log}
@@ -887,7 +887,7 @@ rule split_vcf_files:
     log:
         "results/logs/13_GERP/chunks/" + REF_NAME + "/{dataset}/vcf/{sample}.{processed}_fmissing{fmiss}.{chunk}_split_vcf_chunks.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         bedtools intersect -a {input.vcf} -b {input.chunk_bed} -g {input.genomefile} -header | gzip - > {output.vcf_chunk} 2> {log}
@@ -903,7 +903,7 @@ rule split_chunk_bed_files:
     log:
         "results/logs/13_GERP/" + REF_NAME + ".{chunk}_split_chunk_bed_files.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         bedtools makewindows -b {input.chunk_bed} -w 10000000 > {output.chunk_win_bed} 2> {log}

--- a/workflow/rules/13_GERP.smk
+++ b/workflow/rules/13_GERP.smk
@@ -815,7 +815,7 @@ rule filter_biallelic_missing_vcf_gerp:
     log:
         "results/logs/13_GERP/{dataset}/" + REF_NAME + "/vcf/{sample}.{processed}_fmissing{fmiss}_filter_biallelic_missing_vcf.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         bedtools intersect -a {input.vcf} -b {input.bed} -header -sorted -g {input.genomefile} > {output.filtered} 2> {log}
@@ -887,7 +887,7 @@ rule split_vcf_files:
     log:
         "results/logs/13_GERP/chunks/" + REF_NAME + "/{dataset}/vcf/{sample}.{processed}_fmissing{fmiss}.{chunk}_split_vcf_chunks.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         bedtools intersect -a {input.vcf} -b {input.chunk_bed} -g {input.genomefile} -header | gzip - > {output.vcf_chunk} 2> {log}
@@ -903,7 +903,7 @@ rule split_chunk_bed_files:
     log:
         "results/logs/13_GERP/" + REF_NAME + ".{chunk}_split_chunk_bed_files.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         bedtools makewindows -b {input.chunk_bed} -w 10000000 > {output.chunk_win_bed} 2> {log}

--- a/workflow/rules/5_CpG_identification.smk
+++ b/workflow/rules/5_CpG_identification.smk
@@ -128,7 +128,7 @@ rule merge_CpG_genotype_beds:
     log:
         "results/logs/5_CpG_identification/" + REF_NAME + "_merge_CpG_genotype_beds.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         files=`echo {input} | awk '{{print NF}}'`
@@ -154,7 +154,7 @@ rule sort_CpG_genotype_beds:
     log:
         "results/logs/5_CpG_identification/" + REF_NAME + "_sort_CpG_genotype_beds.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         bedtools sort -g {input.genomefile} -i {input.merged_bed} > {output.sorted_bed} 2> {log}
@@ -174,7 +174,7 @@ rule merge_all_CpG_beds:
     log:
         "results/logs/5_CpG_identification/" + REF_NAME + "_merge_all_CpG_beds.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         files=`echo {input} | awk '{{print NF}}'`
@@ -200,7 +200,7 @@ rule sort_all_CpG_beds:
     log:
         "results/logs/5_CpG_identification/" + REF_NAME + "_sort_all_CpG_beds.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         bedtools sort -g {input.genomefile} -i {input.merged_bed} > {output.sorted_bed} 2> {log}
@@ -217,7 +217,7 @@ rule make_noCpG_bed:
     log:
         "results/logs/5_CpG_identification/" + REF_NAME + ".no{CpG_method}_make_no_CpG_bed.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         bedtools subtract -a {input.ref_bed} -b {input.CpG_bed} > {output.no_CpG_bed} 2> {log}
@@ -238,7 +238,7 @@ rule merge_CpG_repeats_beds:
     log:
         "results/logs/5_CpG_identification/" + REF_NAME + ".{CpG_method}_merge_CpG_repeats_beds.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         cat {input[0]} {input[1]} | sort -k1,1 -k2,2n > {output.tmp} 2> {log} &&
@@ -257,7 +257,7 @@ rule sort_CpG_repeats_beds:
     log:
         "results/logs/5_CpG_identification/" + REF_NAME + ".{CpG_method}_sort_CpG_repeats_beds.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         bedtools sort -g {input.genomefile} -i {input.merged_bed} > {output.sorted_bed} 2> {log}
@@ -274,7 +274,7 @@ rule make_noCpG_repma_bed:
     log:
         "results/logs/5_CpG_identification/" + REF_NAME + ".no{CpG_method}_make_noCpG_repma_bed.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         bedtools subtract -a {input.ref_bed} -b {input.merged_bed} > {output.no_CpG_repma_bed} 2> {log}

--- a/workflow/rules/5_CpG_identification.smk
+++ b/workflow/rules/5_CpG_identification.smk
@@ -128,7 +128,7 @@ rule merge_CpG_genotype_beds:
     log:
         "results/logs/5_CpG_identification/" + REF_NAME + "_merge_CpG_genotype_beds.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         files=`echo {input} | awk '{{print NF}}'`
@@ -154,7 +154,7 @@ rule sort_CpG_genotype_beds:
     log:
         "results/logs/5_CpG_identification/" + REF_NAME + "_sort_CpG_genotype_beds.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         bedtools sort -g {input.genomefile} -i {input.merged_bed} > {output.sorted_bed} 2> {log}
@@ -174,7 +174,7 @@ rule merge_all_CpG_beds:
     log:
         "results/logs/5_CpG_identification/" + REF_NAME + "_merge_all_CpG_beds.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         files=`echo {input} | awk '{{print NF}}'`
@@ -200,7 +200,7 @@ rule sort_all_CpG_beds:
     log:
         "results/logs/5_CpG_identification/" + REF_NAME + "_sort_all_CpG_beds.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         bedtools sort -g {input.genomefile} -i {input.merged_bed} > {output.sorted_bed} 2> {log}
@@ -217,7 +217,7 @@ rule make_noCpG_bed:
     log:
         "results/logs/5_CpG_identification/" + REF_NAME + ".no{CpG_method}_make_no_CpG_bed.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         bedtools subtract -a {input.ref_bed} -b {input.CpG_bed} > {output.no_CpG_bed} 2> {log}
@@ -238,7 +238,7 @@ rule merge_CpG_repeats_beds:
     log:
         "results/logs/5_CpG_identification/" + REF_NAME + ".{CpG_method}_merge_CpG_repeats_beds.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         cat {input[0]} {input[1]} | sort -k1,1 -k2,2n > {output.tmp} 2> {log} &&
@@ -257,7 +257,7 @@ rule sort_CpG_repeats_beds:
     log:
         "results/logs/5_CpG_identification/" + REF_NAME + ".{CpG_method}_sort_CpG_repeats_beds.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         bedtools sort -g {input.genomefile} -i {input.merged_bed} > {output.sorted_bed} 2> {log}
@@ -274,7 +274,7 @@ rule make_noCpG_repma_bed:
     log:
         "results/logs/5_CpG_identification/" + REF_NAME + ".no{CpG_method}_make_noCpG_repma_bed.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         bedtools subtract -a {input.ref_bed} -b {input.merged_bed} > {output.no_CpG_repma_bed} 2> {log}

--- a/workflow/rules/6_autosome_sexchromosome_bed_files.smk
+++ b/workflow/rules/6_autosome_sexchromosome_bed_files.smk
@@ -42,7 +42,7 @@ rule make_autosomes_bed:
     log:
         "results/logs/6_autosome_sexchromosome_bed_files/" + REF_NAME + "_make_autosomes_bed.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         bedtools subtract -a {input.ref_bed} -b {input.sexchr_bed} > {output.autosome_bed} 2> {log}
@@ -61,7 +61,7 @@ rule intersect_sexchr_repma_beds:
     log:
         "results/logs/6_autosome_sexchromosome_bed_files/" + REF_NAME + "_intersect_sexchr_repma_beds.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         bedtools intersect -a {input.no_rep_bed_dir} -b {input.sexchr_bed} > {output.repma_sex_chr} 2> {log}
@@ -80,7 +80,7 @@ rule intersect_autos_repma_beds:
     log:
         "results/logs/6_autosome_sexchromosome_bed_files/" + REF_NAME + "_intersect_autos_repma_beds.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         bedtools intersect -a {input.no_rep_bed_dir} -b {input.autosome_bed} > {output.repma_autos} 2> {log}
@@ -99,7 +99,7 @@ rule intersect_sexchr_noCpG_repma_beds:
     log:
         "results/logs/6_autosome_sexchromosome_bed_files/" + REF_NAME + ".no{CpG_method}_intersect_sexchr_noCpG_repma_beds.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         bedtools intersect -a {input.no_CpG_repma_bed} -b {input.sexchr_bed} > {output.no_CpG_repma_sexchr} 2> {log}
@@ -118,7 +118,7 @@ rule intersect_autos_noCpG_repma_beds:
     log:
         "results/logs/6_autosome_sexchromosome_bed_files/" + REF_NAME + ".no{CpG_method}_intersect_autos_noCpG_repma_beds.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         bedtools intersect -a {input.no_CpG_repma_bed} -b {input.autosome_bed} > {output.no_CpG_repma_autos} 2> {log}

--- a/workflow/rules/6_autosome_sexchromosome_bed_files.smk
+++ b/workflow/rules/6_autosome_sexchromosome_bed_files.smk
@@ -42,7 +42,7 @@ rule make_autosomes_bed:
     log:
         "results/logs/6_autosome_sexchromosome_bed_files/" + REF_NAME + "_make_autosomes_bed.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         bedtools subtract -a {input.ref_bed} -b {input.sexchr_bed} > {output.autosome_bed} 2> {log}
@@ -61,7 +61,7 @@ rule intersect_sexchr_repma_beds:
     log:
         "results/logs/6_autosome_sexchromosome_bed_files/" + REF_NAME + "_intersect_sexchr_repma_beds.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         bedtools intersect -a {input.no_rep_bed_dir} -b {input.sexchr_bed} > {output.repma_sex_chr} 2> {log}
@@ -80,7 +80,7 @@ rule intersect_autos_repma_beds:
     log:
         "results/logs/6_autosome_sexchromosome_bed_files/" + REF_NAME + "_intersect_autos_repma_beds.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         bedtools intersect -a {input.no_rep_bed_dir} -b {input.autosome_bed} > {output.repma_autos} 2> {log}
@@ -99,7 +99,7 @@ rule intersect_sexchr_noCpG_repma_beds:
     log:
         "results/logs/6_autosome_sexchromosome_bed_files/" + REF_NAME + ".no{CpG_method}_intersect_sexchr_noCpG_repma_beds.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         bedtools intersect -a {input.no_CpG_repma_bed} -b {input.sexchr_bed} > {output.no_CpG_repma_sexchr} 2> {log}
@@ -118,7 +118,7 @@ rule intersect_autos_noCpG_repma_beds:
     log:
         "results/logs/6_autosome_sexchromosome_bed_files/" + REF_NAME + ".no{CpG_method}_intersect_autos_noCpG_repma_beds.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         bedtools intersect -a {input.no_CpG_repma_bed} -b {input.autosome_bed} > {output.no_CpG_repma_autos} 2> {log}

--- a/workflow/rules/8.1_vcf_CpG_filtering.smk
+++ b/workflow/rules/8.1_vcf_CpG_filtering.smk
@@ -107,7 +107,7 @@ rule remove_CpG_vcf:
     log:
         "results/logs/8.1_vcf_CpG_filtering/{dataset}/" + REF_NAME + "/{sample}.{processed}.no{CpG_method}_remove_CpG_vcf.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         bedtools intersect -a {input.vcf} -b {input.bed} -header -sorted -g {input.genomefile} | bgzip -c > {output.filtered} 2> {log}

--- a/workflow/rules/8.1_vcf_CpG_filtering.smk
+++ b/workflow/rules/8.1_vcf_CpG_filtering.smk
@@ -102,7 +102,7 @@ rule remove_CpG_vcf:
         bed=rules.make_noCpG_bed.output.no_CpG_bed,
         genomefile=rules.genome_file.output.genomefile,
     output:
-        filtered=temp("results/{dataset}/vcf/" + REF_NAME + "/{sample}.merged.rmdup.merged.{processed}.Q30.sorted.no{CpG_method}.vcf"),
+        filtered=temp("results/{dataset}/vcf/" + REF_NAME + "/{sample}.merged.rmdup.merged.{processed}.Q30.sorted.no{CpG_method}.vcf.gz"),
     threads: 6
     log:
         "results/logs/8.1_vcf_CpG_filtering/{dataset}/" + REF_NAME + "/{sample}.{processed}.no{CpG_method}_remove_CpG_vcf.log",
@@ -110,7 +110,7 @@ rule remove_CpG_vcf:
         "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
-        bedtools intersect -a {input.vcf} -b {input.bed} -header -sorted -g {input.genomefile} > {output.filtered} 2> {log}
+        bedtools intersect -a {input.vcf} -b {input.bed} -header -sorted -g {input.genomefile} | bgzip -c > {output.filtered} 2> {log}
         """
 
 

--- a/workflow/rules/8.1_vcf_CpG_filtering.smk
+++ b/workflow/rules/8.1_vcf_CpG_filtering.smk
@@ -107,7 +107,7 @@ rule remove_CpG_vcf:
     log:
         "results/logs/8.1_vcf_CpG_filtering/{dataset}/" + REF_NAME + "/{sample}.{processed}.no{CpG_method}_remove_CpG_vcf.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         bedtools intersect -a {input.vcf} -b {input.bed} -header -sorted -g {input.genomefile} > {output.filtered} 2> {log}

--- a/workflow/rules/8.2_vcf_qual_repeat_filtering.smk
+++ b/workflow/rules/8.2_vcf_qual_repeat_filtering.smk
@@ -367,7 +367,7 @@ rule remove_repeats_vcf:
     log:
         "results/logs/8.2_vcf_qual_repeat_filtering/{dataset}/" + REF_NAME + "/{sample}.{processed}_remove_repeats_vcf.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         bedtools intersect -a {input.vcf} -b {input.bed} -header -sorted -g {input.genomefile} > {output.filtered} 2> {log}

--- a/workflow/rules/8.2_vcf_qual_repeat_filtering.smk
+++ b/workflow/rules/8.2_vcf_qual_repeat_filtering.smk
@@ -367,7 +367,7 @@ rule remove_repeats_vcf:
     log:
         "results/logs/8.2_vcf_qual_repeat_filtering/{dataset}/" + REF_NAME + "/{sample}.{processed}_remove_repeats_vcf.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         bedtools intersect -a {input.vcf} -b {input.bed} -header -sorted -g {input.genomefile} | bgzip -c > {output.filtered} 2> {log}

--- a/workflow/rules/8.2_vcf_qual_repeat_filtering.smk
+++ b/workflow/rules/8.2_vcf_qual_repeat_filtering.smk
@@ -362,7 +362,7 @@ rule remove_repeats_vcf:
         bed=rules.make_no_repeats_bed.output.no_rep_bed_dir,
         genomefile=rules.genome_file.output.genomefile,
     output:
-        filtered=temp("results/{dataset}/vcf/" + REF_NAME + "/{sample}.merged.rmdup.merged.{processed}.snps5.noIndel.QUAL30.dp.AB.repma.vcf"),
+        filtered=temp("results/{dataset}/vcf/" + REF_NAME + "/{sample}.merged.rmdup.merged.{processed}.snps5.noIndel.QUAL30.dp.AB.repma.vcf.gz"),
     threads: 6
     log:
         "results/logs/8.2_vcf_qual_repeat_filtering/{dataset}/" + REF_NAME + "/{sample}.{processed}_remove_repeats_vcf.log",
@@ -370,7 +370,7 @@ rule remove_repeats_vcf:
         "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
-        bedtools intersect -a {input.vcf} -b {input.bed} -header -sorted -g {input.genomefile} > {output.filtered} 2> {log}
+        bedtools intersect -a {input.vcf} -b {input.bed} -header -sorted -g {input.genomefile} | bgzip -c > {output.filtered} 2> {log}
         """
 
 

--- a/workflow/rules/9_merge_vcfs.smk
+++ b/workflow/rules/9_merge_vcfs.smk
@@ -340,7 +340,7 @@ rule filtered_vcf2bed:
     log:
         "results/logs/9_merge_vcfs/" + REF_NAME + ".all_fmissing{fmiss}_filtered_vcf2bed.log",
     singularity:
-        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
+        "docker://nbisweden/generode-bedtools-2.29.2"
     shell:
         """
         gzip -cd {input.vcf} | grep -v "^#" | awk -F'\t' '{{print $1, $2-1, $2}}' OFS='\t' > {output.bed} 2> {log}

--- a/workflow/rules/9_merge_vcfs.smk
+++ b/workflow/rules/9_merge_vcfs.smk
@@ -340,7 +340,7 @@ rule filtered_vcf2bed:
     log:
         "results/logs/9_merge_vcfs/" + REF_NAME + ".all_fmissing{fmiss}_filtered_vcf2bed.log",
     singularity:
-        "docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
+        "docker://verku/bedtools-2.29.2" # replace with link to NBIS Dockerhub repo
     shell:
         """
         gzip -cd {input.vcf} | grep -v "^#" | awk -F'\t' '{{print $1, $2-1, $2}}' OFS='\t' > {output.bed} 2> {log}


### PR DESCRIPTION
Docker images currently on private Dockerhub repository. Add them to NBIS Dockerhub and update links to bedtools image in the rules before merging this branch.